### PR TITLE
Specify minimum YAML version

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -8,6 +8,9 @@ license             = Perl_5
 :version = 0.088
 Test::MinimumVersion.max_target_perl = 5.008
 
+[Prereqs]
+YAML = 1.15
+
 [Prereqs / DevelopRequires]
 Test::Warnings = 0
 


### PR DESCRIPTION
Tests are failed with older `YAML`(<= 1.14) after `d2a4989b53999cce52182ee4a6383cc11bd0b5c9` change.
